### PR TITLE
Increasing alert expiration

### DIFF
--- a/arkime/config.ini
+++ b/arkime/config.ini
@@ -15,7 +15,7 @@
 debug=2
 plugins=suricata.so
 suricataAlertFile=/suricata/logs/eve.json
-suricataExpireMinutes=1525600
+suricataExpireMinutes=9999999
 
 # Comma seperated list of elasticsearch host:port combinations.  If not using a
 # Elasticsearch load balancer, a different elasticsearch node in the cluster can be specified


### PR DESCRIPTION
The allowed expiration needs to be increased so Suricata alerts with 2019 timestamps, due to the pcap having 2019 timestamps, are noticed by Arkime.
- This is a fix for the _Signatures and Sessions: Malware HTTP Analysis_ lab having this issue.
- Not sure if other labs uses this repo.; _should_ be okay to make the change, as any other labs that use this are likely similarly broke, but I don't have enough context to guarantee that.

Please @ me (github and/or slack) if you merge this, as I should then get rid of a tf workaround I implemented for that lab.